### PR TITLE
Example for issue #448

### DIFF
--- a/src/main/java/de/lessvoid/issues/issue448/Issue448Main.java
+++ b/src/main/java/de/lessvoid/issues/issue448/Issue448Main.java
@@ -1,0 +1,53 @@
+package de.lessvoid.issues.issue448;
+
+import java.util.logging.Logger;
+
+import com.jogamp.newt.opengl.GLWindow;
+
+import de.lessvoid.issues.JOGLNiftyRunner;
+import de.lessvoid.issues.JOGLNiftyRunner.Callback;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class Issue448Main implements ScreenController {
+	private static final Logger LOGGER = Logger.getLogger(Issue448Main.class.getName());
+	
+	private Screen screen;
+	
+	private long time;
+	
+	@Override
+	public void bind(Nifty arg0, Screen screen) {
+		this.screen = screen;
+	}
+
+	@Override
+	public void onEndScreen() {}
+
+	@Override
+	public void onStartScreen() {
+		this.time = System.currentTimeMillis();
+		LOGGER.info("setVisible(false)");
+		this.screen.findElementById("panel").setVisible(false);
+	}
+	
+	public void start() {
+		long time = System.currentTimeMillis();
+		LOGGER.info("Starting onHide (" + (time - this.time) + " ms after setVisible)");
+		this.time = time;
+	}
+	
+	public void end() {
+		LOGGER.info("Ending onHide (" + (System.currentTimeMillis() - this.time) + " ms after start)");
+	}
+	
+	public static void main(String[] args) throws Exception {
+        JOGLNiftyRunner.run(args, new Callback() {
+            @Override
+            public void init(final Nifty nifty, final GLWindow glWindow) {
+                nifty.fromXml("src/main/resources/de/lessvoid/issues/issue448/issue448.xml", "start");
+            }
+        });
+	}
+}

--- a/src/main/resources/de/lessvoid/issues/issue448/issue448.xml
+++ b/src/main/resources/de/lessvoid/issues/issue448/issue448.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+	<useStyles filename="nifty-default-styles.xml" />
+	<useControls filename="nifty-default-controls.xml "/>
+	<screen id="start" controller="de.lessvoid.issues.issue448.Issue448Main">
+		<layer id="layer" childLayout="horizontal">
+			<panel id="panel" width="400px" height="400px" backgroundColor="#500f">
+				<effect>
+					<onHide name="nop" onStartEffect="start()" onEndEffect="end()" />
+				</effect>
+			</panel>
+		</layer>
+	</screen>
+</nifty>


### PR DESCRIPTION
https://github.com/nifty-gui/nifty-gui/issues/448

It takes more than a second to hide an element when onHide effect is present.

Debug output on my computer:
```
INFO: setVisible(false)
INFO: Starting onHide (3 ms after setVisible)
INFO: Ending onHide (1059 ms after start)
```