### PR TITLE
Added examples for ScrollPanel issues

### DIFF
--- a/src/main/java/de/lessvoid/issues/issue449/Issue449Main1a.java
+++ b/src/main/java/de/lessvoid/issues/issue449/Issue449Main1a.java
@@ -1,0 +1,48 @@
+package de.lessvoid.issues.issue449;
+
+import com.jogamp.newt.opengl.GLWindow;
+
+import de.lessvoid.issues.JOGLNiftyRunner;
+import de.lessvoid.issues.JOGLNiftyRunner.Callback;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.TextBuilder;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class Issue449Main1a implements ScreenController {
+	private Nifty nifty;
+	private Screen screen;
+	
+	@Override
+	public void bind(Nifty nifty, Screen screen) {
+		this.nifty = nifty;
+		this.screen = screen;
+	}
+
+	@Override
+	public void onEndScreen() {}
+
+	@Override
+	public void onStartScreen() {
+		Element parent = this.screen.findElementById("cpanel");
+		for(int i=0; i < 25; i++) {
+			TextBuilder text = new TextBuilder();
+			text.text("Lorem ipsum dolor sit amet");
+			text.style("base-font");
+			text.color("#000f");
+			text.build(this.nifty, this.screen, parent);
+		}
+		
+		//page size of ScrollPanel is not updated when adding elements to its nested panel
+	}
+	
+	public static void main(String[] args) throws Exception {
+        JOGLNiftyRunner.run(args, new Callback() {
+            @Override
+            public void init(final Nifty nifty, final GLWindow glWindow) {
+                nifty.fromXml("src/main/resources/de/lessvoid/issues/issue449/issue449_1a.xml", "start");
+            }
+        });
+	}
+}

--- a/src/main/java/de/lessvoid/issues/issue449/Issue449Main1b.java
+++ b/src/main/java/de/lessvoid/issues/issue449/Issue449Main1b.java
@@ -1,0 +1,48 @@
+package de.lessvoid.issues.issue449;
+
+import com.jogamp.newt.opengl.GLWindow;
+
+import de.lessvoid.issues.JOGLNiftyRunner;
+import de.lessvoid.issues.JOGLNiftyRunner.Callback;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.TextBuilder;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class Issue449Main1b implements ScreenController {
+	private Nifty nifty;
+	private Screen screen;
+	
+	@Override
+	public void bind(Nifty nifty, Screen screen) {
+		this.nifty = nifty;
+		this.screen = screen;
+	}
+
+	@Override
+	public void onEndScreen() {}
+
+	@Override
+	public void onStartScreen() {
+		Element parent = this.screen.findElementById("sp");
+		for(int i=0; i < 25; i++) {
+			TextBuilder text = new TextBuilder();
+			text.text("Lorem ipsum dolor sit amet");
+			text.style("base-font");
+			text.color("#000f");
+			text.build(this.nifty, this.screen, parent);
+		}
+		
+		//WARNING: Attempted to render image with negative height (Scrollbar issue)
+	}
+	
+	public static void main(String[] args) throws Exception {
+        JOGLNiftyRunner.run(args, new Callback() {
+            @Override
+            public void init(final Nifty nifty, final GLWindow glWindow) {
+                nifty.fromXml("src/main/resources/de/lessvoid/issues/issue449/issue449_1b.xml", "start");
+            }
+        });
+	}
+}

--- a/src/main/java/de/lessvoid/issues/issue449/Issue449Main2a.java
+++ b/src/main/java/de/lessvoid/issues/issue449/Issue449Main2a.java
@@ -1,0 +1,63 @@
+package de.lessvoid.issues.issue449;
+
+import com.jogamp.newt.opengl.GLWindow;
+
+import de.lessvoid.issues.JOGLNiftyRunner;
+import de.lessvoid.issues.JOGLNiftyRunner.Callback;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.ElementBuilder.ChildLayoutType;
+import de.lessvoid.nifty.builder.PanelBuilder;
+import de.lessvoid.nifty.builder.TextBuilder;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class Issue449Main2a implements ScreenController {
+	private Nifty nifty;
+	private Screen screen;
+	
+	@Override
+	public void bind(Nifty nifty, Screen screen) {
+		this.nifty = nifty;
+		this.screen = screen;
+	}
+
+	@Override
+	public void onEndScreen() {}
+
+	@Override
+	public void onStartScreen() {
+		Element parent = this.screen.findElementById("cpanel");
+		String s[] = new String[] {"Lorem", "ipsum", "dolor", "sit", "amet"};
+		for(int i=0; i < 5; i++) {
+			TextBuilder text = new TextBuilder();
+			text.text(s[i]);
+			text.style("base-font");
+			text.color("#000f");
+			text.build(this.nifty, this.screen, parent);
+			
+			PanelBuilder panel = new PanelBuilder();
+			panel.childLayout(ChildLayoutType.AbsoluteInside);
+			Element p = panel.build(this.nifty, this.screen, parent);
+			
+			text = new TextBuilder();
+			text.text(s[i]);
+			text.style("base-font");
+			text.color("#000f");
+			text.x("10px");
+			text.y("10px");
+			text.build(this.nifty, this.screen, p);
+		}
+		
+		//texts are stacked on each other
+	}
+	
+	public static void main(String[] args) throws Exception {
+        JOGLNiftyRunner.run(args, new Callback() {
+            @Override
+            public void init(final Nifty nifty, final GLWindow glWindow) {
+                nifty.fromXml("src/main/resources/de/lessvoid/issues/issue449/issue449_2a.xml", "start");
+            }
+        });
+	}
+}

--- a/src/main/java/de/lessvoid/issues/issue449/Issue449Main2b.java
+++ b/src/main/java/de/lessvoid/issues/issue449/Issue449Main2b.java
@@ -1,0 +1,61 @@
+package de.lessvoid.issues.issue449;
+
+import com.jogamp.newt.opengl.GLWindow;
+
+import de.lessvoid.issues.JOGLNiftyRunner;
+import de.lessvoid.issues.JOGLNiftyRunner.Callback;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.ElementBuilder.ChildLayoutType;
+import de.lessvoid.nifty.builder.ImageBuilder;
+import de.lessvoid.nifty.builder.PanelBuilder;
+import de.lessvoid.nifty.builder.TextBuilder;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class Issue449Main2b implements ScreenController {
+	private Nifty nifty;
+	private Screen screen;
+	
+	@Override
+	public void bind(Nifty nifty, Screen screen) {
+		this.nifty = nifty;
+		this.screen = screen;
+	}
+
+	@Override
+	public void onEndScreen() {}
+
+	@Override
+	public void onStartScreen() {
+		Element parent = this.screen.findElementById("cpanel");
+		String s[] = new String[] {"Lorem", "ipsum", "dolor", "sit", "amet"};
+		for(int i=0; i < 5; i++) {
+			TextBuilder text = new TextBuilder();
+			text.text(s[i]);
+			text.style("base-font");
+			text.color("#000f");
+			text.build(this.nifty, this.screen, parent);
+			
+			PanelBuilder panel = new PanelBuilder();
+			panel.childLayout(ChildLayoutType.AbsoluteInside);
+			Element p = panel.build(this.nifty, this.screen, parent);
+			
+			ImageBuilder image = new ImageBuilder();
+			image.filename("src/main/resources/icon.png");
+			image.build(this.nifty, this.screen, p);
+		}
+		
+		//WARNING: Attempted to render image with negative height
+		//created image won't render; it works fine when the panel does not have AbsoluteInside layout
+	}
+	
+	public static void main(String[] args) throws Exception {
+        JOGLNiftyRunner.run(args, new Callback() {
+            @Override
+            public void init(final Nifty nifty, final GLWindow glWindow) {
+                nifty.fromXml("src/main/resources/de/lessvoid/issues/issue449/issue449_2b.xml", "start");
+            }
+        });
+	}
+}

--- a/src/main/resources/de/lessvoid/issues/issue449/issue449_1a.xml
+++ b/src/main/resources/de/lessvoid/issues/issue449/issue449_1a.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+	<useStyles filename="nifty-default-styles.xml" />
+	<useControls filename="nifty-default-controls.xml "/>
+	<screen id="start" controller="de.lessvoid.issues.issue449.Issue449Main1a">
+		<layer id="layer" childLayout="vertical" backgroundColor="#999f">
+			<control name="scrollPanel" width="400" height="400">
+				<panel id="cpanel" childLayout="vertical" backgroundColor="#0f0f" />
+			</control>
+		</layer>
+	</screen>
+</nifty>

--- a/src/main/resources/de/lessvoid/issues/issue449/issue449_1b.xml
+++ b/src/main/resources/de/lessvoid/issues/issue449/issue449_1b.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+	<useStyles filename="nifty-default-styles.xml" />
+	<useControls filename="nifty-default-controls.xml "/>
+	<screen id="start" controller="de.lessvoid.issues.issue449.Issue449Main1b">
+		<layer id="layer" childLayout="vertical" backgroundColor="#999f">
+			<control id="sp" name="scrollPanel" width="400" height="400" />
+		</layer>
+	</screen>
+</nifty>

--- a/src/main/resources/de/lessvoid/issues/issue449/issue449_2a.xml
+++ b/src/main/resources/de/lessvoid/issues/issue449/issue449_2a.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+	<useStyles filename="nifty-default-styles.xml" />
+	<useControls filename="nifty-default-controls.xml "/>
+	<screen id="start" controller="de.lessvoid.issues.issue449.Issue449Main2a">
+		<layer id="layer" childLayout="vertical" backgroundColor="#999f">
+			<control name="scrollPanel" width="400" height="400">
+				<panel id="cpanel" childLayout="vertical" backgroundColor="#0f0f" />
+			</control>
+		</layer>
+	</screen>
+</nifty>

--- a/src/main/resources/de/lessvoid/issues/issue449/issue449_2b.xml
+++ b/src/main/resources/de/lessvoid/issues/issue449/issue449_2b.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+	<useStyles filename="nifty-default-styles.xml" />
+	<useControls filename="nifty-default-controls.xml "/>
+	<screen id="start" controller="de.lessvoid.issues.issue449.Issue449Main2b">
+		<layer id="layer" childLayout="vertical" backgroundColor="#999f">
+			<control name="scrollPanel" width="400" height="400">
+				<panel id="cpanel" childLayout="vertical" backgroundColor="#0f0f" />
+			</control>
+		</layer>
+	</screen>
+</nifty>


### PR DESCRIPTION
https://github.com/nifty-gui/nifty-gui/issues/449

1. **Issues directly with ScrollPanel:**
a. `Issue449Main1a.java`: Page size of ScrollPanel is not updated elements are added to its nested panel.
b. `Issue449Main1b.java`: When more elements than ScrollPanel can display are added, Scrollbar won't display properly.
`WARNING: Attempted to render image with negative height`
2. **Issues with panel (AbsoluteInside layout) inside ScrollPanel:**
a. `Issue449Main2a.java`: Texts are stacked on each other when there is a panel with this layout.
b. `Issue449Main2b.java`: Image won't render when there is a panel with this layout. Moreover, a warning is displayed when the image is added to the panel directly.